### PR TITLE
🤖 Analyse hebdomadaire IA (2026-08-06)

### DIFF
--- a/.ai/analyse-2026-08-06.md
+++ b/.ai/analyse-2026-08-06.md
@@ -1,0 +1,73 @@
+## Résumé
+
+Cocoyico est un petit bot Discord monofichier (`cocoyico.py`) qui gère des notes/tags persistées dans `tags.json`. L’idée est simple et fonctionnelle, mais la mise en œuvre manque de robustesse : pas de sauvegarde atomique, pas de permissions, tags globalement partagés entre tous les serveurs, intents trop larges, et tests très limités. Les actions prioritaires sont de protéger les fichiers sensibles (`secrets.json`, `tags.json`), fiabiliser la persistance, et restreindre l’usage des commandes.
+
+## Problèmes et bugs potentiels
+
+- `cocoyico.py` : `addtag` utilise `bot.wait_for('message', check=check)` sans `timeout`. Si l’utilisateur ne répond pas, la commande reste bloquée indéfiniment.
+- Le `check` de `addtag` accepte n’importe quel message du même auteur dans le même salon, y compris une autre commande `;...`. Cette commande serait alors enregistrée comme contenu du tag.
+- `tags[title] = content.content` écrase silencieusement un tag existant. Aucune vérification de doublon ni demande de confirmation.
+- Les tags sont stockés dans un seul dictionnaire global `tags`, sans identifiant de serveur. Un tag créé sur un serveur est visible et modifiable depuis tous les autres serveurs.
+- Aucune vérification de permissions : n’importe quel membre peut exécuter `;addtag`, `;removetag`, `;tagedit`, `;tagrename`.
+- `;server_list` est probablement accessible à tous les utilisateurs, ce qui peut révéler la liste des serveurs du bot à des membres non autorisés. Cette commande devrait être réservée au propriétaire.
+- `tags_lock` est défini mais n’est pas utilisé dans l’extrait visible de `addtag`. S’il est utilisé autour d’opérations asynchrones, un `threading.Lock` bloquant peut geler l’event loop. Un `asyncio.Lock` serait plus adapté.
+- Le chargement de `tags.json` n’est pas robuste : un fichier contenant du JSON invalide, un tableau, ou `null` peut faire planter le bot au démarrage.
+- `addtag(ctx, title: str)` ne capture qu’un seul mot. Les titres avec espaces nécessitent des guillemets, ce qui n’est pas documenté dans le README.
+- L’extrait visible ne montre pas d’appel de sauvegarde après `tags[title] = ...`. Si la sauvegarde est absente, les tags ajoutés seront perdus au redémarrage.
+- Absence de `.gitignore` dans l’arborescence : `secrets.json` et `tags.json` peuvent être commités accidentellement.
+
+## Qualité du code et nettoyage
+
+- Le code tient dans un seul fichier, ce qui est acceptable pour un petit script, mais la logique de stockage est mélangée avec les commandes Discord. Extraire des fonctions dédiées : `load_tags()`, `save_tags()`, `add_tag()`, `remove_tag()`.
+- Le global `tags` rend le code difficile à tester et à maintenir. Une classe `TagStore` avec un verrou asynchrone et des méthodes métier serait plus propre.
+- `tags_lock` est soit inutilisé, soit utilisé partiellement. Il faut l’appliquer systématiquement à toutes les lectures/écritures, ou le supprimer.
+- `intents = discord.Intents.all()` est beaucoup trop large. Utiliser `discord.Intents.default()` + `message_content=True` suffit pour ce bot.
+- Les commentaires du code sont en anglais alors que le README est en français. Ce n’est pas bloquant, mais une uniformisation aiderait la maintenance.
+- Ajouter des messages d’erreur clairs et des `try/except` autour des accès à `tags.json`, au lieu de laisser le bot crasher.
+- Le fichier de test `tests/test_config.py` est un script manuel, pas une suite pytest. Le faire migrer vers `pytest` permettrait une intégration CI plus naturelle.
+
+## Nouvelles fonctionnalités à envisager
+
+- Tags par serveur : utiliser `guild_id` comme clé, ou un mélange tags globaux/tags locaux.
+- Permissions configurables : restreindre les commandes d’écriture aux rôles avec `manage_messages` ou `administrator`.
+- Timeout dans les invites `addtag` / `tagedit`, avec possibilité d’annuler en envoyant `cancel`.
+- Sauvegarde automatique : écrire `tags.json` de façon atomique (`tempfile` + `os.replace`) et conserver une copie `tags.json.bak`.
+- Pagination de `;taglist` si le nombre de tags devient important.
+- Commande d’export/import JSON pour sauvegarder ou restaurer les tags facilement.
+
+## Tests manquants
+
+- `tests/test_config.py` ne vérifie que la présence d’un objet JSON dict. Il manque :
+  - test de chargement avec `tags.json` absent ;
+  - test de chargement avec JSON invalide ;
+  - test de chargement avec un contenu non-dict (liste, `null`) ;
+  - test de sauvegarde atomique : après une mutation, le fichier est valide et contient les nouvelles données ;
+  - test d’écrasement de tag existant ;
+  - test du timeout de `wait_for` ;
+  - test de rejet des messages de commande comme contenu de tag ;
+  - test de permissions : utilisateur non autorisé ne peut pas modifier les tags ;
+  - test d’isolation multi-serveurs.
+- Aucun test ne couvre les commandes `removetag`, `tagedit`, `tagrename`, `taglist`, `server_list`.
+- Le CI semble limité à ce test de configuration ; ajouter au moins `pytest` et `flake8` dans `.github/workflows/python-ci.yml`.
+
+## Dépendances et sécurité
+
+- `requirements.txt` contient `discord.py>=2.7.1` sans borne supérieure. Une future version majeure pourrait casser le bot. Utiliser une version épinglée (`discord.py==2.7.1`) ou une contrainte `~=2.7.1`.
+- Aucun `.gitignore` n’est présent dans l’arborescence. Ajouter au minimum :
+  - `secrets.json`
+  - `tags.json`
+  - `__pycache__/`
+  - `.venv/`
+  - `.env`
+- Si `tags.json` a déjà été tracké, exécuter `git rm --cached tags.json` pour arrêter son suivi.
+- `secrets.json` contient le token Discord. En plus du `.gitignore`, vérifier que les permissions du fichier sont restrictives (`chmod 600`).
+- Le workflow `secret-scan.yml` est un bon point de départ, mais il ne remplace pas un `.gitignore` efficace.
+- `Intents.all()` demande des privilèges Discord inutiles et expose plus de données que nécessaire. Réduire les intents aux seuls besoins du bot.
+
+## Suggestions prioritaires (top 5)
+
+1. Ajouter un `.gitignore` et retirer `tags.json` / `secrets.json` du suivi Git.
+2. Refactorer la persistance : `TagStore` avec `asyncio.Lock`, validation du JSON, sauvegarde atomique après chaque mutation.
+3. Restreindre les commandes sensibles par permissions et cloisonner les tags par serveur (`guild_id`).
+4. Rendre `addtag` / `tagedit` robustes : timeout, filtrage des messages de commande, rejet des doublons, support des titres multi-mots via `*, title: str`.
+5. Épingler `discord.py` et enrichir les tests CI (`pytest`) pour couvrir la persistance et les commandes critiques.


### PR DESCRIPTION
## Résumé

Cocoyico est un petit bot Discord monofichier (`cocoyico.py`) qui gère des notes/tags persistées dans `tags.json`. L’idée est simple et fonctionnelle, mais la mise en œuvre manque de robustesse : pas de sauvegarde atomique, pas de permissions, tags globalement partagés entre tous les serveurs, intents trop larges, et tests très limités. Les actions prioritaires sont de protéger les fichiers sensibles (`secrets.json`, `tags.json`), fiabiliser la persistance, et restreindre l’usage des commandes.

## Problèmes et bugs potentiels

- `cocoyico.py` : `addtag` utilise `bot.wait_for('message', check=check)` sans `timeout`. Si l’utilisateur ne répond pas, la commande reste bloquée indéfiniment.
- Le `check` de `addtag` accepte n’importe quel message du même auteur dans le même salon, y compris une autre commande `;...`. Cette commande serait alors enregistrée comme contenu du tag.
- `tags[title] = content.content` écrase silencieusement un tag existant. Aucune vérification de doublon ni demande de confirmation.
- Les tags sont stockés dans un seul dictionnaire global `tags`, sans identifiant de serveur. Un tag créé sur un serveur est visible et modifiable depuis tous les autres serveurs.
- Aucune vérification de permissions : n’importe quel membre peut exécuter `;addtag`, `;removetag`, `;tagedit`, `;tagrename`.
- `;server_list` est probablement accessible à tous les utilisateurs, ce qui peut révéler la liste des serveurs du bot à des membres non autorisés. Cette commande devrait être réservée au propriétaire.
- `tags_lock` est défini mais n’est pas utilisé dans l’extrait visible de `addtag`. S’il est utilisé autour d’opérations asynchrones, un `threading.Lock` bloquant peut geler l’event loop. Un `asyncio.Lock` serait plus adapté.
- Le chargement de `tags.json` n’est pas robuste : un fichier contenant du JSON invalide, un tableau, ou `null` peut faire planter le bot au démarrage.
- `addtag(ctx, title: str)` ne capture qu’un seul mot. Les titres avec espaces nécessitent des guillemets, ce qui n’est pas documenté dans le README.
- L’extrait visible ne montre pas d’appel de sauvegarde après `tags[title] = ...`. Si la sauvegarde est absente, les tags ajoutés seront perdus au redémarrage.
- Absence de `.gitignore` dans l’arborescence : `secrets.json` et `tags.json` peuvent être commités accidentellement.

## Qualité du code et nettoyage

- Le code tient dans un seul fichier, ce qui est acceptable pour un petit script, mais la logique de stockage est mélangée avec les commandes Discord. Extraire des fonctions dédiées : `load_tags()`, `save_tags()`, `add_tag()`, `remove_tag()`.
- Le global `tags` rend le code difficile à tester et à maintenir. Une classe `TagStore` avec un verrou asynchrone et des méthodes métier serait plus propre.
- `tags_lock` est soit inutilisé, soit utilisé partiellement. Il faut l’appliquer systématiquement à toutes les lectures/écritures, ou le supprimer.
- `intents = discord.Intents.all()` est beaucoup trop large. Utiliser `discord.Intents.default()` + `message_content=True` suffit pour ce bot.
- Les commentaires du code sont en anglais alors que le README est en français. Ce n’est pas bloquant, mais une uniformisation aiderait la maintenance.
- Ajouter des messages d’erreur clairs et des `try/except` autour des accès à `tags.json`, au lieu de laisser le bot crasher.
- Le fichier de test `tests/test_config.py` est un script manuel, pas une suite pytest. Le faire migrer vers `pytest` permettrait une intégration CI plus naturelle.

## Nouvelles fonctionnalités à envisager

- Tags par serveur : utiliser `guild_id` comme clé, ou un mélange tags globaux/tags locaux.
- Permissions configurables : restreindre les commandes d’écriture aux rôles avec `manage_messages` ou `administrator`.
- Timeout dans les invites `addtag` / `tagedit`, avec possibilité d’annuler en envoyant `cancel`.
- Sauvegarde automatique : écrire `tags.json` de façon atomique (`tempfile` + `os.replace`) et conserver une copie `tags.json.bak`.
- Pagination de `;taglist` si le nombre de tags devient important.
- Commande d’export/import JSON pour sauvegarder ou restaurer les tags facilement.

## Tests manquants

- `tests/test_config.py` ne vérifie que la présence d’un objet JSON dict. Il manque :
  - test de chargement avec `tags.json` absent ;
  - test de chargement avec JSON invalide ;
  - test de chargement avec un contenu non-dict (liste, `null`) ;
  - test de sauvegarde atomique : après une mutation, le fichier est valide et contient les nouvelles données ;
  - test d’écrasement de tag existant ;
  - test du timeout de `wait_for` ;
  - test de rejet des messages de commande comme contenu de tag ;
  - test de permissions : utilisateur non autorisé ne peut pas modifier les tags ;
  - test d’isolation multi-serveurs.
- Aucun test ne couvre les commandes `removetag`, `tagedit`, `tagrename`, `taglist`, `server_list`.
- Le CI semble limité à ce test de configuration ; ajouter au moins `pytest` et `flake8` dans `.github/workflows/python-ci.yml`.

## Dépendances et sécurité

- `requirements.txt` contient `discord.py>=2.7.1` sans borne supérieure. Une future version majeure pourrait casser le bot. Utiliser une version épinglée (`discord.py==2.7.1`) ou une contrainte `~=2.7.1`.
- Aucun `.gitignore` n’est présent dans l’arborescence. Ajouter au minimum :
  - `secrets.json`
  - `tags.json`
  - `__pycache__/`
  - `.venv/`
  - `.env`
- Si `tags.json` a déjà été tracké, exécuter `git rm --cached tags.json` pour arrêter son suivi.
- `secrets.json` contient le token Discord. En plus du `.gitignore`, vérifier que les permissions du fichier sont restrictives (`chmod 600`).
- Le workflow `secret-scan.yml` est un bon point de départ, mais il ne remplace pas un `.gitignore` efficace.
- `Intents.all()` demande des privilèges Discord inutiles et expose plus de données que nécessaire. Réduire les intents aux seuls besoins du bot.

## Suggestions prioritaires (top 5)

1. Ajouter un `.gitignore` et retirer `tags.json` / `secrets.json` du suivi Git.
2. Refactorer la persistance : `TagStore` avec `asyncio.Lock`, validation du JSON, sauvegarde atomique après chaque mutation.
3. Restreindre les commandes sensibles par permissions et cloisonner les tags par serveur (`guild_id`).
4. Rendre `addtag` / `tagedit` robustes : timeout, filtrage des messages de commande, rejet des doublons, support des titres multi-mots via `*, title: str`.
5. Épingler `discord.py` et enrichir les tests CI (`pytest`) pour couvrir la persistance et les commandes critiques.